### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project bundles the Camel Web Console, REST API, and some sample routes.
 
 ###Camel Router WAR Project with Web Console and REST Support
 
+Navigate to the jetty folder in the project you just cloned and then:
+
 Just run
 
 ```


### PR DESCRIPTION
Added instruction to navigate to jetty folder before running mvn jetty run. If not the server still starts but in the port 8080 and the training exercises will not work properly.